### PR TITLE
Remove pty reference.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "express": "^4.15.2",
     "ip": "^1.1.5",
     "mkdirp": "^0.5.1",
-    "pty.js": "^0.3.1",
     "repl.history": "^0.1.4",
     "reserved-words": "^0.1.1",
     "source-map": "^0.5.6",


### PR DESCRIPTION
1) The package isn't being maintained
2) The package is basically broken.
3) There's another package that _is_ being maintained.
4) It's not being used anywhere.